### PR TITLE
#163047527 Creates a view all meetups endpoint

### DIFF
--- a/app/api/v1/models/meetups_model.py
+++ b/app/api/v1/models/meetups_model.py
@@ -38,3 +38,8 @@ class MeetUpsModel():
         return jsonify({"msg":"user was added","data":self.meetups , "status":200})
 
 
+    def get_meetups(self):
+        if len(self.meetups) == 0:
+            return jsonify({"msg":"no users were found","data":self.meetups , "status":200})
+
+        return jsonify({"msg":"users","data":self.meetups , "status":200})

--- a/app/api/v1/views/meetups_view.py
+++ b/app/api/v1/views/meetups_view.py
@@ -12,4 +12,4 @@ def add_meetup():
 
 @meetupV1.route('/meetups/upcoming', methods=['GET'])
 def get_meetup():
-	return meetups_model.get_meetup(request)
+	return meetups_model.get_meetups()

--- a/app/api/v1/views/meetups_view.py
+++ b/app/api/v1/views/meetups_view.py
@@ -9,3 +9,7 @@ meetups_model = MeetUpsModel()
 @meetupV1.route('/meetups', methods=['POST'])
 def add_meetup():
 	return meetups_model.add_meetup(request)
+
+@meetupV1.route('/meetups/upcoming', methods=['GET'])
+def get_meetup():
+	return meetups_model.get_meetup(request)

--- a/app/tests/v1/test_meetups.py
+++ b/app/tests/v1/test_meetups.py
@@ -35,37 +35,38 @@ class MeetupTest(SetUpTestClient):
         self.assertEqual(res.status_code,400)
         self.assertIn('sent an empty request',res.data)
 
-        def test_get_all_meetups():
-            meetup = {
-                    "location" : "Eldoret",
-                    "images"   : ["run.png" , "marathon.jpg" , "cross.png"],
-                    "topic"    : "Athletes",
-                    "happeningOn" : datetime.datetime(2019, 5, 17),
-                    "Tags"         : ["sports","IAAF","AK"]
-            }
+    def test_get_all_meetups(self):
+        """ Return all upcoming meetups """
+        meetup = {
+                "location" : "Eldoret",
+                "images"   : ["run.png" , "marathon.jpg" , "cross.png"],
+                "topic"    : "Athletes",
+                "happeningOn" : datetime.datetime(2019, 5, 17),
+                "Tags"         : ["sports","IAAF","AK"]
+        }
 
-            meetup_one = {
-                    "location" : "Kileleshwa",
-                    "images"   : ["lawyers.png" , "doctors.jpg" , "teachers.png"],
-                    "topic"    : "Career Talk",
-                    "happeningOn" : datetime.datetime(2019, 5, 17),
-                    "Tags"         : ["law","medicine","Education"]
-            }
+        meetup_one = {
+                "location" : "",
+                "images"   : ["lawyers.png" , "doctors.jpg" , "teachers.png"],
+                "topic"    : "Career Talk",
+                "happeningOn" : datetime.datetime(2019, 5, 17),
+                "Tags"         : ["law","medicine","Education"]
+        }
 
-            meetup_two = {
-                    "location" : "IHUB",
-                    "images"   : ["coders.png" , "developers.jpg" , "facebook.png"],
-                    "topic"    : "Women in tech",
-                    "happeningOn" : datetime.datetime(2019, 5, 17),
-                    "Tags"         : ["women","mums","ladies"]
-            }
-            res = self.client.post("/api/v1/meetups",json=meetup,content_type='application/json')
-            self.assertEqual(res.status_code,200)
-            res = self.client.post("/api/v1/meetups",json=meetup_one,content_type='application/json')
-            self.assertEqual(res.status_code,200)
-            res = self.client.post("/api/v1/meetups",json=meetup_two,content_type='application/json')
-            self.assertEqual(res.status_code,200)
+        meetup_two = {
+                "location" : "IHUB",
+                "images"   : ["coders.png" , "developers.jpg" , "facebook.png"],
+                "topic"    : "Women in tech",
+                "happeningOn" : datetime.datetime(2019, 5, 17),
+                "Tags"         : ["women","mums","ladies"]
+        }
+        res = self.client.post("/api/v1/meetups",json=meetup,content_type='application/json')
+        self.assertEqual(res.status_code,200)
+        res = self.client.post("/api/v1/meetups",json=meetup_one,content_type='application/json')
+        self.assertEqual(res.status_code,400)
+        res = self.client.post("/api/v1/meetups",json=meetup_two,content_type='application/json')
+        self.assertEqual(res.status_code,200)
 
-            res = self.client.get("/api/v1/meetups/upcoming")
-            self.assertEqual(res.status_code,200)
+        res = self.client.get("/api/v1/meetups/upcoming")
+        self.assertEqual(res.status_code,200)
 

--- a/app/tests/v1/test_meetups.py
+++ b/app/tests/v1/test_meetups.py
@@ -37,25 +37,25 @@ class MeetupTest(SetUpTestClient):
 
         def test_get_all_meetups():
             meetup = {
-                    "location" : "Kileleshwa",
-                    "images"   : ["hello.png" , "wazito.jpg" , "babayao.png"],
-                    "topic"    : "Kilimani Mums",
+                    "location" : "Eldoret",
+                    "images"   : ["run.png" , "marathon.jpg" , "cross.png"],
+                    "topic"    : "Athletes",
                     "happeningOn" : datetime.datetime(2019, 5, 17),
-                    "Tags"         : ["women","mums","ladies"]
+                    "Tags"         : ["sports","IAAF","AK"]
             }
 
             meetup_one = {
                     "location" : "Kileleshwa",
-                    "images"   : ["hello.png" , "wazito.jpg" , "babayao.png"],
-                    "topic"    : "Kilimani Mums",
+                    "images"   : ["lawyers.png" , "doctors.jpg" , "teachers.png"],
+                    "topic"    : "Career Talk",
                     "happeningOn" : datetime.datetime(2019, 5, 17),
-                    "Tags"         : ["women","mums","ladies"]
+                    "Tags"         : ["law","medicine","Education"]
             }
 
             meetup_two = {
-                    "location" : "Kileleshwa",
-                    "images"   : ["hello.png" , "wazito.jpg" , "babayao.png"],
-                    "topic"    : "Kilimani Mums",
+                    "location" : "IHUB",
+                    "images"   : ["coders.png" , "developers.jpg" , "facebook.png"],
+                    "topic"    : "Women in tech",
                     "happeningOn" : datetime.datetime(2019, 5, 17),
                     "Tags"         : ["women","mums","ladies"]
             }
@@ -66,6 +66,6 @@ class MeetupTest(SetUpTestClient):
             res = self.client.post("/api/v1/meetups",json=meetup_two,content_type='application/json')
             self.assertEqual(res.status_code,200)
 
-            res = self.client.get("/api/v1/meetups/upcoming",json=meetup,content_type='application/json')
+            res = self.client.get("/api/v1/meetups/upcoming")
             self.assertEqual(res.status_code,200)
 

--- a/app/tests/v1/test_meetups.py
+++ b/app/tests/v1/test_meetups.py
@@ -34,3 +34,38 @@ class MeetupTest(SetUpTestClient):
         res = self.client.post("/api/v1/meetups",json=meetup_empty,content_type='application/json')
         self.assertEqual(res.status_code,400)
         self.assertIn('sent an empty request',res.data)
+
+        def test_get_all_meetups():
+            meetup = {
+                    "location" : "Kileleshwa",
+                    "images"   : ["hello.png" , "wazito.jpg" , "babayao.png"],
+                    "topic"    : "Kilimani Mums",
+                    "happeningOn" : datetime.datetime(2019, 5, 17),
+                    "Tags"         : ["women","mums","ladies"]
+            }
+
+            meetup_one = {
+                    "location" : "Kileleshwa",
+                    "images"   : ["hello.png" , "wazito.jpg" , "babayao.png"],
+                    "topic"    : "Kilimani Mums",
+                    "happeningOn" : datetime.datetime(2019, 5, 17),
+                    "Tags"         : ["women","mums","ladies"]
+            }
+
+            meetup_two = {
+                    "location" : "Kileleshwa",
+                    "images"   : ["hello.png" , "wazito.jpg" , "babayao.png"],
+                    "topic"    : "Kilimani Mums",
+                    "happeningOn" : datetime.datetime(2019, 5, 17),
+                    "Tags"         : ["women","mums","ladies"]
+            }
+            res = self.client.post("/api/v1/meetups",json=meetup,content_type='application/json')
+            self.assertEqual(res.status_code,200)
+            res = self.client.post("/api/v1/meetups",json=meetup_one,content_type='application/json')
+            self.assertEqual(res.status_code,200)
+            res = self.client.post("/api/v1/meetups",json=meetup_two,content_type='application/json')
+            self.assertEqual(res.status_code,200)
+
+            res = self.client.get("/api/v1/meetups/upcoming",json=meetup,content_type='application/json')
+            self.assertEqual(res.status_code,200)
+


### PR DESCRIPTION
**What does this pull request do**
- Adds a view all meetups endpoint 


**Description of the task to be completed**
- Add tests for view meetup endpoint 
- Add endpoint view upcoming  meetup records

**How should this be manually tested**
- Clone or fork the repository 
`$ git clone https://github.com/Felix45/Questioner.git`

- Open a terminal and change working directory to Questioner
`$ cd Questioner`

- Install a virtual environment
`$ virtualenv env`

- Once the environment is up activate it using
`$ source env/bin/activate`

- Install all the requirements for the application using
`$ pip install -r requirements.txt`

- Checkout to branch ft-view-all-meetups-163047527
`$ git checkout ft-view-all-meetups-163047527 `
- Enter the following commands in to your terminal
```
$ export FLASK_APP=app
$ export FLASK_ENV=development 
$ export FLASK_DEBUG=1
flask run
```
Open a test client of your choice preferably post man and make the the following requests, here i'm using post man
**Screen Shots**
```
POST http://127.0.0.1/api/v1/meetups/upcoming
```
![upcoming](https://user-images.githubusercontent.com/16392046/50953437-6f011c00-14c4-11e9-8903-f1e299f468d9.png)

```
POST http://127.0.0.1/api/v1/meetups
{
                    "location" : "Kileleshwa",
                    "images"   : ["survivor.png" , "well.jpg" , "healed.png"],
                    "topic"    : "Breast cancer Warriors",
                    "happeningOn" : "2019, 5, 17",
                    "Tags"         : ["women","mums","ladies"]
}

{
                "location" : "IHUB",
                "images"   : ["coders.png" , "developers.jpg" , "facebook.png"],
                "topic"    : "Women in tech",
                "happeningOn" : datetime.datetime(2019, 5, 17),
                "Tags"         : ["women","mums","ladies"]
        }
```
```
POST http://127.0.0.1/api/v1/meetups/upcoming 
```
**Result**
![upcoming](https://user-images.githubusercontent.com/16392046/50953437-6f011c00-14c4-11e9-8903-f1e299f468d9.png)


