### PR TITLE
#163206583 fixes navigation and adds span links

### DIFF
--- a/UI/static/styles/style.css
+++ b/UI/static/styles/style.css
@@ -667,5 +667,3 @@ footer #scroll-top{
 			border-left:1px solid #ddd;
 		}
 }
-
-

--- a/UI/static/styles/style.css
+++ b/UI/static/styles/style.css
@@ -417,6 +417,7 @@ main ol li span{
 footer{
 	color: #fff;
 	margin: 0;
+	margin-top:30px;
 	padding:30px;
 	position: relative;
 	background-color: #009688;

--- a/UI/static/styles/style.css
+++ b/UI/static/styles/style.css
@@ -350,7 +350,30 @@ main ol li span{
 	color: #009688;
 	display: block;
 }
+.pagination {
 
+
+}
+.pagination li{
+	width:30px;
+	height:30px;
+	color:#009688;
+	display: inline-block;
+	border-bottom:none;
+	background-color: #fff;
+	border: 1px solid #009688;
+}
+.pagination li a{
+	color: #009688;
+
+}
+.pagination .active{
+	
+	background-color: #009688;
+}
+.pagination .active a{
+	color: #fff;
+}
 .modal{
 	width: 100%;
 	height: 100%;

--- a/UI/templates/deletemeetup.html
+++ b/UI/templates/deletemeetup.html
@@ -19,7 +19,7 @@
 				<!-- Uniform application header section -->
 					<div class="column-lg-2 column-md-2 column-sm-1 column-xs-2">
 						<div class="logo">
-						  <a href="" title="go to home">
+						  <a href="index.html" title="go to home">
 							<img src="../static/images/logo.png" class="img" alt="Questioner" />		
 						  </a>				
 						</div>
@@ -38,8 +38,8 @@
 					<div class="column-lg-4 column-md-4 column-sm-4 column-xs-4">
 					  <nav class="menu">
 						<ul>
-							<li><a href=""> <span class="fa fa-user-o"></span> Account (Admin) </a></li>	
-							<li><a href=""> <span class="fa fa-sign-out"></span> Sign Out </a></li>				
+							<li><a href="admindash.html"> <span class="fa fa-user-o"></span> Account (Admin) </a></li>	
+							<li><a href="login.html"> <span class="fa fa-sign-out"></span> Sign Out </a></li>				
 						</ul>	
 					   </nav>				
 					</div>				
@@ -78,10 +78,10 @@
 								 	<div class="column-lg-12 column-md-12 column-sm-12 column-xs-12">
 								 	<nav>
 							   		<ul class="admin-menu">
-							   			<li><a href="" class="block success"><span class="fa fa-plus"></span> Add Meetup</a></li>
-							   			<li><a href="" class="block danger"><span class="fa fa-trash-o"></span> Delete Meetup</a></li>
-							   			<li><a href="" class="block info"><span class="fa fa-eye"></span> View Meetups</a></li>
-							   			<li><a href="" class="block warning"><span class="fa fa-sign-out"></span> Sign Out</a></li>
+							   			<li><a href="createmeetup.html" class="block success"><span class="fa fa-plus"></span> Add Meetup</a></li>
+							   			<li><a href="deletemeetup.html" class="block danger"><span class="fa fa-trash-o"></span> Delete Meetup</a></li>
+							   			<li><a href="meetups.html" class="block info"><span class="fa fa-eye"></span> View Meetups</a></li>
+							   			<li><a href="login.html" class="block warning"><span class="fa fa-sign-out"></span> Sign Out</a></li>
 							   		</ul>
 							   	  </nav>
 							   	</div>	
@@ -106,7 +106,7 @@
 					<div class="cards">
 						<h4>Artificial Intelligence</h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/artificial.jpg" class="img" alt="Artificial Intelligence">	
 							</a>
 							<div class="meetup-details">
@@ -122,7 +122,7 @@
 					<div class="cards">
 						<h4>Game Development</h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/gamedevelopment.png" class="img" alt="Game Development">
 							</a>	
 							<div class="meetup-details">
@@ -138,7 +138,7 @@
 					<div class="cards">
 						<h4>Python Data Science</h4>
 						<div class="meetup">
-						   <a href="">
+						   <a href="postquestion.html">
 								<img src="../static/images/python.jpg" class="img" alt="Python Data Science">	
 							</a>
 							<div class="meetup-details">
@@ -154,7 +154,7 @@
 					<div class="cards">
 						<h4>Virtual Reality</h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/var.jpg" class="img" alt="Virtual Reality">	
 							</a>
 							<div class="meetup-details">
@@ -175,7 +175,7 @@
 					<div class="cards">
 						<h4>Artificial Intelligence</h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/artificial.jpg" class="img" alt="Artificial Intelligence">	
 							</a>
 							<div class="meetup-details">
@@ -191,7 +191,7 @@
 					<div class="cards">
 						<h4>Cake Baking</h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/cakebaking.jpg" class="img" alt="Cake baking">	
 							</a>
 							<div class="meetup-details">
@@ -207,7 +207,7 @@
 					<div class="cards">
 						<h4>Alcoholics </h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/alcoholics.jpg" class="img" alt="Alcoholics Annonymous">	
 							</a>
 							<div class="meetup-details">
@@ -223,7 +223,7 @@
 					<div class="cards">
 						<h4>Constitution Talk</h4>
 						<div class="meetup">
-							<a href="">
+							<a href="postquestion.html">
 								<img src="../static/images/parliament.jpg" class="img" alt="Constitution Talk">	
 							</a>	
 							<div class="meetup-details">
@@ -234,6 +234,25 @@
 						<span class="attending danger delete-meetup fa fa-trash-o" onclick="displayModal()" title="delete"></span>
 					</div>
 				</div>	
+
+				 <!-- start pagination links -->
+	   	<div class="row">
+	   		<div class="column-lg-12 column-md-12 column-sm-12 column-xs-12">
+				<ol class="pagination center-text">
+					<li><a href="" class="block">&laquo;</a></li>
+					<li><a href="" class="block">1</a></li>
+					<li><a href="" class="block">2</a></li>
+					<li><a href="" class="block">3</a></li>
+					<li class="active"><a href="">4</a></li>
+					<li><a href="" class="block">5</a></li>
+					<li><a href="" class="block">6</a></li>
+					<li><a href="" class="block">7</a></li>
+					<li><a href="" class="block">&raquo;</a></li>
+				</ol>
+			</div>
+		</div>
+
+			<!-- -->	
 						
 			</div>
 			
@@ -293,10 +312,12 @@
 	   		</div>
 	   			<span class="fa fa-times danger close" onclick="displayModal()"></span>
 	   	</div>
+
 	   
 	   </div>
 	   
 	   <!-- End Confirm dialog box -->
+
 	   	
 			
 		
@@ -306,7 +327,7 @@
 		<!-- Start footer section -->
 		<footer>
 			<div class="column-lg-12 column-md-12 column-sm-12 column-xs-12">
-				<a href="" title="Questioner">&copy;Questioner 2019</a>
+				<a href="index.html" title="Questioner">&copy;Questioner 2019</a>
 				<a id="scroll-top" href="#top" class="fa fa-angle-up fa-lg">
 				
 				</a>
@@ -318,10 +339,11 @@
 	   <!-- Drawer menu for tablet and mobile devices -->
 	    <div class="drawer-menu" id="mobile-menu">
 	    	<ul>
-				<li><a href=""><span class="fa fa-home"></span> Questioner </a></li>
-				<li><a href=""><span class="fa fa-sign-in"></span> Sign In </a></li>
-				<li><a href=""><span class="fa fa-user-o"></span> Sign Up </a></li>
-				<li><a href=""><span class="fa fa-user-o"></span> Administrator</a></li>	    	
+				<li><a href="index.html"><span class="fa fa-home"></span> Questioner </a></li>
+				<li><a href="login.html"><span class="fa fa-sign-in"></span> Sign In </a></li>
+				<li><a href="registration.html"><span class="fa fa-user-o"></span> Sign Up </a></li>
+				<li><a href="profile.html"><span class="fa fa-user-o"></span> Account(Felix45)</a></li>	  
+				<li><a href="admindash.html"><span class="fa fa-user-o"></span> Administrator</a></li>	    	
 	    	</ul>
 	    </div>
 	   

--- a/UI/templates/index.html
+++ b/UI/templates/index.html
@@ -66,7 +66,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>					
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -82,7 +84,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -98,7 +102,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -114,7 +120,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">07</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">07</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -131,7 +139,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">01</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">01</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -147,7 +157,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">05</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">05</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -163,7 +175,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">12</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">12</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -179,7 +193,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>					
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 						

--- a/UI/templates/index.html
+++ b/UI/templates/index.html
@@ -201,7 +201,15 @@
 						
 			</div>
 			
-			<!-- End the popular meetups section -->		
+			<!-- End the popular meetups section -->	
+
+			<!-- Add readmore section-->
+			<div class="row">
+				<div class="column-lg-12 column-md-12 column-sm-12 column-xs-12 center-text">
+					<a href="meetups.html" class="button"> View More &raquo; </a>
+				</div>
+			</div>
+			<!-- End the readmore section -->	
 		</main>
 	 </div>
 		

--- a/UI/templates/meetups.html
+++ b/UI/templates/meetups.html
@@ -120,7 +120,7 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<a href="">
+						<a href="postquestion.html">
 							<span class="attending" title="People attending">07</span>
 						</a>
 					</div>

--- a/UI/templates/meetups.html
+++ b/UI/templates/meetups.html
@@ -205,14 +205,16 @@
 			<!-- End the all meetups section -->	
 
 			<!-- start pagination links -->
-				<ol class="pagination">
-					<li><a href=""></a></li>
-					<li><a href=""></a></li>
-					<li><a href=""></a></li>
-					<li><a href=""></a></li>
-					<li><a href=""></a></li>
-					<li><a href=""></a></li>
-					<li><a href=""></a></li>
+				<ol class="pagination center-text">
+					<li><a href="" class="block">&laquo;</a></li>
+					<li><a href="" class="block">1</a></li>
+					<li><a href="" class="block">2</a></li>
+					<li><a href="" class="block">3</a></li>
+					<li class="active"><a href="">4</a></li>
+					<li><a href="" class="block">5</a></li>
+					<li><a href="" class="block">6</a></li>
+					<li><a href="" class="block">7</a></li>
+					<li><a href="" class="block">&raquo;</a></li>
 				</ol>
 
 			<!-- -->	

--- a/UI/templates/meetups.html
+++ b/UI/templates/meetups.html
@@ -66,7 +66,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>					
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -82,7 +84,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -98,7 +102,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -114,7 +120,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">07</span>
+						<a href="">
+							<span class="attending" title="People attending">07</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -131,7 +139,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">01</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">01</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -147,7 +157,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">05</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">05</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -163,7 +175,9 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>						
 						</div>
-						<span class="attending" title="People attending">12</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">12</span>
+						</a>
 					</div>
 				</div>	
 				
@@ -179,13 +193,29 @@
 								<span>  12/01/2019  Venue: Base </span>
 							</div>					
 						</div>
-						<span class="attending" title="People attending">10</span>
+						<a href="postquestion.html">
+							<span class="attending" title="People attending">10</span>
+						</a>
 					</div>
 				</div>	
 						
 			</div>
+
 			
-			<!-- End the all meetups section -->		
+			<!-- End the all meetups section -->	
+
+			<!-- start pagination links -->
+				<ol class="pagination">
+					<li><a href=""></a></li>
+					<li><a href=""></a></li>
+					<li><a href=""></a></li>
+					<li><a href=""></a></li>
+					<li><a href=""></a></li>
+					<li><a href=""></a></li>
+					<li><a href=""></a></li>
+				</ol>
+
+			<!-- -->	
 		</main>
 	 </div>
 		


### PR DESCRIPTION
**What does this pull request do**
- Fixes  navigation links on home page

**Description of the task to be completed**
- Add a read more button at the bottom of the page
- Add navigation links to the span attendance  navigation icons
- Add navigation links to the delete meetups page and all meetups page

**How should this be manually tested**
- Clone or fork the repository 
`$ git clone https://github.com/Felix45/Questioner.git`

- Change the working directory to the project directory
`$ cd Questioner`

- Checkout to branch bg-fix-navigation-span-links-163206583
`$ git checkout bg-fix-navigation-span-links-163206583`

- Change working directory to UI/templates
`$ cd UI/templates`
- Open the file meetups.html using a browser of your choice

**Desktop View**
![navigation](https://user-images.githubusercontent.com/16392046/51147425-3c13ab00-186b-11e9-9438-b823dd39297f.png)


**Another View**
![navigation-two](https://user-images.githubusercontent.com/16392046/51147441-49c93080-186b-11e9-8733-d841320ae36c.png)



