### PR TITLE
[finishes #163589849] Finish fixing the delete meetup modal

### DIFF
--- a/UI/static/styles/style.css
+++ b/UI/static/styles/style.css
@@ -377,11 +377,13 @@ main ol li span{
 .modal{
 	width: 100%;
 	height: 100%;
-	position:absolute;
+	position:fixed;
 	left:0;
 	top:0;
 	display: none;
 	z-index: 99999;
+	overflow-y: scroll;
+	background-color: rgba(0,0,0,0.9)
 }
 .modal .dashboard p{
 	padding: 10px 10px 0;
@@ -392,6 +394,7 @@ main ol li span{
 	position: relative;
 	margin: 170px auto;
 	position: relative;
+	
 	border: 1px solid #ddd;
 	background-color: #fff;
 }

--- a/UI/templates/deletemeetup.html
+++ b/UI/templates/deletemeetup.html
@@ -272,7 +272,7 @@
 	   	<div class="modal-body">
 	   		<div class="modal-header">
 	   			<div class="row">
-	   				<div class="column-lg-4 column-md-4 column-sm-4 column-xs-12">
+	   				<div class="column-lg-4 column-md-4 column-sm-6 column-xs-12">
 	   					<div class="cards no-box-shadow">
 								<h4>Artificial Intelligence</h4>
 									<div class="meetup">
@@ -287,7 +287,7 @@
 									<span class="attending danger delete-meetup fa fa-trash-o" title="delete"></span>
 					    		</div>
 	   					</div>
-	   				<div class="dashboard column-lg-8 column-md-8 column-sm-8 column-xs-12">
+	   				<div class="dashboard column-lg-8 column-md-8 column-sm-6 column-xs-12">
 	   					<h2 class="danger-text">Do you want to delete this meetup ?</h2>
 	   					<div class="divider"></div>
 	   					<p class="meetup-details">Title: Artificial Intelligence</p>


### PR DESCRIPTION
**What does this pull request do**
- Fixes delete meetup model for it to hide background elements.

**Description of the task to be completed**
- Add CSS rules for the modal to display correctly


**How should this be manually tested**
- Checkout to branch bg-fix-delete-modal-163589849
`$ git checkout bg-fix-delete-modal-163589849 `

**Related pivotal tracker stories**
[Fix the delete meetup model](https://www.pivotaltracker.com/n/projects/2235209/stories/163589849)

**Screenshots**
![deletemeetup](https://user-images.githubusercontent.com/16392046/51985921-1ebc1f00-24b0-11e9-89b0-0ead74099cf3.png)

**Tablet View**
![tablet_delete_meetup](https://user-images.githubusercontent.com/16392046/51985953-2d0a3b00-24b0-11e9-8ef0-8d30abf46770.png)

**Mobile View**
![delete_meetup_phone](https://user-images.githubusercontent.com/16392046/51985979-3abfc080-24b0-11e9-9beb-df8f3e2da44e.png)


